### PR TITLE
Add timestamps, sort feed by recents first

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -207,6 +207,7 @@ router.get('/feed', async ctx => {
   const { limit = 10, offset = 0 } = ctx.query;
   ctx.body = await knex('users')
     .select('name', 'story', 'kudos', 'streak','avatar_url')
+    .orderBy('updated_at', 'desc')
     .limit(Math.min(100, limit))
     .offset(offset);
 });
@@ -223,6 +224,7 @@ async function startup() {
       table.integer('streak').unsigned().notNullable();
       table.text('story').notNullable();
       table.bigInteger('kudos').notNullable();
+      table.timestamps();
     });
 
     await knex('users').insert([


### PR DESCRIPTION
fügt `updated_at` und `created_at` hinzu, die automatisch bei INSERT / UPDATE gesetzt/aktualisiert werden